### PR TITLE
fix: harden market provider reliability (P1–P4 from Codex review)

### DIFF
--- a/backend/market/indian_api.py
+++ b/backend/market/indian_api.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import random
 from datetime import datetime, timezone
 
 import httpx
@@ -11,6 +12,8 @@ logger = logging.getLogger(__name__)
 
 BASE_URL = "https://stock.indianapi.in"
 POLL_INTERVAL = 15
+MAX_POLL_INTERVAL = 300
+POLL_JITTER = 5.0
 REQUEST_TIMEOUT = 10.0
 HISTORY_LIMIT = 200
 
@@ -22,7 +25,11 @@ def _parse_response(ticker: str, data: dict, prev: StockPrice | None) -> StockPr
     if not price_raw:
         return None
 
-    price = float(price_raw)
+    try:
+        price = float(price_raw)
+    except (TypeError, ValueError):
+        return None
+
     if price <= 0:
         return None
 
@@ -57,6 +64,8 @@ class IndianAPIProvider(MarketDataProvider):
         self._task: asyncio.Task | None = None
 
     async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
         self._task = asyncio.create_task(self._poll_loop())
 
     async def stop(self) -> None:
@@ -66,6 +75,7 @@ class IndianAPIProvider(MarketDataProvider):
                 await self._task
             except asyncio.CancelledError:
                 pass
+            self._task = None
 
     def get_price(self, ticker: str) -> StockPrice | None:
         return self._cache.get(ticker)
@@ -77,20 +87,37 @@ class IndianAPIProvider(MarketDataProvider):
         return list(self._history.get(ticker, []))[-limit:]
 
     def set_tickers(self, tickers: list[str]) -> None:
+        removed = set(self._tickers) - set(tickers)
+        for ticker in removed:
+            self._cache.pop(ticker, None)
+            self._history.pop(ticker, None)
         self._tickers = list(tickers)
 
     async def _poll_loop(self) -> None:
+        consecutive_failures = 0
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
             while True:
                 if self._tickers:
-                    await self._poll_all(client)
-                await asyncio.sleep(POLL_INTERVAL)
+                    successes = await self._poll_all(client)
+                    if successes == 0:
+                        consecutive_failures += 1
+                    else:
+                        consecutive_failures = 0
+                else:
+                    consecutive_failures = 0
+                delay = min(POLL_INTERVAL * (2 ** consecutive_failures), MAX_POLL_INTERVAL)
+                delay += random.uniform(0, POLL_JITTER)
+                await asyncio.sleep(delay)
 
-    async def _poll_all(self, client: httpx.AsyncClient) -> None:
-        """Fetch all tickers concurrently; log errors without interrupting the stream."""
+    async def _poll_all(self, client: httpx.AsyncClient) -> int:
+        """Fetch all tickers concurrently; log errors without interrupting the stream.
+
+        Returns the number of tickers successfully updated.
+        """
         tasks = [_fetch_one(client, t, self._api_key) for t in self._tickers]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
+        successes = 0
         for ticker, result in zip(self._tickers, results):
             if isinstance(result, Exception):
                 logger.warning("IndianAPI poll failed for %s: %s", ticker, result)
@@ -107,3 +134,6 @@ class IndianAPIProvider(MarketDataProvider):
             buf.append(sp)
             if len(buf) > HISTORY_LIMIT:
                 self._history[ticker] = buf[-HISTORY_LIMIT:]
+            successes += 1
+
+        return successes

--- a/backend/market/simulator.py
+++ b/backend/market/simulator.py
@@ -73,6 +73,8 @@ class SimulatorProvider(MarketDataProvider):
         self._task: asyncio.Task | None = None
 
     async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
         self._task = asyncio.create_task(self._simulate_loop())
 
     async def stop(self) -> None:
@@ -82,6 +84,7 @@ class SimulatorProvider(MarketDataProvider):
                 await self._task
             except asyncio.CancelledError:
                 pass
+            self._task = None
 
     def get_price(self, ticker: str) -> StockPrice | None:
         return self._cache.get(ticker)
@@ -93,6 +96,11 @@ class SimulatorProvider(MarketDataProvider):
         return list(self._history.get(ticker, []))[-limit:]
 
     def set_tickers(self, tickers: list[str]) -> None:
+        removed = set(self._tickers) - set(tickers)
+        for ticker in removed:
+            self._cache.pop(ticker, None)
+            self._history.pop(ticker, None)
+
         now = datetime.now(timezone.utc)
         for ticker in tickers:
             if ticker not in self._cache:

--- a/backend/tests/test_indian_api.py
+++ b/backend/tests/test_indian_api.py
@@ -294,3 +294,147 @@ async def test_stop_is_idempotent():
     await provider.start()
     await provider.stop()
     await provider.stop()  # Should not raise
+
+
+# ── _parse_response: defensive numeric parsing ──────────────────────────────
+
+
+def test_parse_returns_none_on_string_price():
+    data = {**SAMPLE_RESPONSE, "currentPrice": {"NSE": "not-a-number"}}
+    sp = _parse_response("RELIANCE", data, prev=None)
+    assert sp is None
+
+
+def test_parse_returns_none_on_dict_price():
+    data = {**SAMPLE_RESPONSE, "currentPrice": {"NSE": {"nested": "object"}}}
+    sp = _parse_response("RELIANCE", data, prev=None)
+    assert sp is None
+
+
+def test_parse_accepts_string_encoded_number():
+    data = {**SAMPLE_RESPONSE, "currentPrice": {"NSE": "2195.75"}}
+    sp = _parse_response("RELIANCE", data, prev=None)
+    assert sp is not None
+    assert sp.price == 2195.75
+
+
+# ── IndianAPIProvider: set_tickers prunes stale state ───────────────────────
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_set_tickers_prunes_stale_cache():
+    respx.get(f"{BASE_URL}/stock").mock(
+        return_value=httpx.Response(200, json=SAMPLE_RESPONSE)
+    )
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE", "TCS"])
+    async with httpx.AsyncClient() as client:
+        await provider._poll_all(client)
+
+    assert provider.get_price("RELIANCE") is not None
+
+    provider.set_tickers(["TCS"])
+    assert provider.get_price("RELIANCE") is None
+    assert "RELIANCE" not in provider._cache
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_set_tickers_prunes_stale_history():
+    respx.get(f"{BASE_URL}/stock").mock(
+        return_value=httpx.Response(200, json=SAMPLE_RESPONSE)
+    )
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE"])
+    async with httpx.AsyncClient() as client:
+        await provider._poll_all(client)
+        await provider._poll_all(client)
+
+    assert len(provider.get_history("RELIANCE")) > 0
+
+    provider.set_tickers([])
+    assert provider.get_history("RELIANCE") == []
+    assert "RELIANCE" not in provider._history
+
+
+def test_set_tickers_keeps_retained_cache():
+    provider = IndianAPIProvider("test-key")
+    provider._cache["TCS"] = StockPrice("TCS", 3440.0, 3430.0, 0.3, datetime.now(timezone.utc))
+    provider.set_tickers(["TCS", "RELIANCE"])
+    provider.set_tickers(["TCS"])
+    assert provider.get_price("TCS") is not None
+
+
+# ── IndianAPIProvider: double-start guard ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_double_start_does_not_create_duplicate_task():
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers([])
+
+    await provider.start()
+    task_first = provider._task
+
+    await provider.start()
+    assert provider._task is task_first
+
+    await provider.stop()
+
+
+@pytest.mark.asyncio
+async def test_task_is_none_after_stop():
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers([])
+    await provider.start()
+    await provider.stop()
+    assert provider._task is None
+
+
+@pytest.mark.asyncio
+async def test_restart_after_stop_creates_new_task():
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers([])
+
+    await provider.start()
+    await provider.stop()
+    assert provider._task is None
+
+    await provider.start()
+    assert provider._task is not None
+    assert not provider._task.done()
+
+    await provider.stop()
+
+
+# ── IndianAPIProvider: _poll_all success count ───────────────────────────────
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_poll_all_returns_success_count():
+    respx.get(f"{BASE_URL}/stock", params={"name": "RELIANCE"}).mock(
+        return_value=httpx.Response(200, json=SAMPLE_RESPONSE)
+    )
+    respx.get(f"{BASE_URL}/stock", params={"name": "TCS"}).mock(
+        return_value=httpx.Response(500)
+    )
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE", "TCS"])
+    async with httpx.AsyncClient() as client:
+        count = await provider._poll_all(client)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_poll_all_returns_zero_on_all_failures():
+    respx.get(f"{BASE_URL}/stock").mock(return_value=httpx.Response(503))
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE"])
+    async with httpx.AsyncClient() as client:
+        count = await provider._poll_all(client)
+
+    assert count == 0

--- a/backend/tests/test_simulator.py
+++ b/backend/tests/test_simulator.py
@@ -271,3 +271,81 @@ def test_dt_is_small_positive():
 def test_all_ticker_vols_present():
     for ticker in SEED_PRICES:
         assert ticker in TICKER_VOL
+
+
+# ── SimulatorProvider: set_tickers prunes stale state ────────────────────────
+
+
+def test_set_tickers_prunes_stale_cache():
+    provider = SimulatorProvider()
+    provider.set_tickers(["RELIANCE", "TCS"])
+    assert provider.get_price("RELIANCE") is not None
+
+    provider.set_tickers(["TCS"])
+    assert provider.get_price("RELIANCE") is None
+    assert "RELIANCE" not in provider.get_all_prices()
+
+
+def test_set_tickers_prunes_stale_history():
+    provider = SimulatorProvider()
+    provider.set_tickers(["RELIANCE", "TCS"])
+    for _ in range(5):
+        provider._tick()
+    assert len(provider.get_history("RELIANCE")) > 0
+
+    provider.set_tickers(["TCS"])
+    assert provider.get_history("RELIANCE") == []
+    assert "RELIANCE" not in provider._history
+
+
+def test_set_tickers_keeps_retained_tickers():
+    provider = SimulatorProvider()
+    provider.set_tickers(["RELIANCE", "TCS"])
+    for _ in range(3):
+        provider._tick()
+
+    provider.set_tickers(["TCS"])
+    assert provider.get_price("TCS") is not None
+    assert len(provider.get_history("TCS")) == 3
+
+
+# ── SimulatorProvider: double-start guard ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_double_start_does_not_create_duplicate_task():
+    provider = SimulatorProvider()
+    provider.set_tickers(["RELIANCE"])
+
+    await provider.start()
+    task_first = provider._task
+
+    await provider.start()
+    assert provider._task is task_first
+
+    await provider.stop()
+
+
+@pytest.mark.asyncio
+async def test_task_is_none_after_stop():
+    provider = SimulatorProvider()
+    provider.set_tickers(["RELIANCE"])
+    await provider.start()
+    await provider.stop()
+    assert provider._task is None
+
+
+@pytest.mark.asyncio
+async def test_restart_after_stop_creates_new_task():
+    provider = SimulatorProvider()
+    provider.set_tickers(["RELIANCE"])
+
+    await provider.start()
+    await provider.stop()
+    assert provider._task is None
+
+    await provider.start()
+    assert provider._task is not None
+    assert not provider._task.done()
+
+    await provider.stop()


### PR DESCRIPTION
Implements the high-priority hardening fixes identified in `planning/Codex_Code_Review.md`:

- **P1**: `set_tickers` now prunes stale cache/history for removed tickers
- **P2**: `start()` guarded against duplicate tasks; `stop()` resets `_task = None`
- **P3**: Exponential backoff + jitter in `IndianAPIProvider._poll_loop`
- **P4**: Defensive `float()` conversion in `_parse_response`

Closes #8

Generated with [Claude Code](https://claude.ai/code)