### PR TITLE
fix: respect 5000 calls/month quota and 1 req/sec rate limit for IndianAPI

### DIFF
--- a/backend/market/indian_api.py
+++ b/backend/market/indian_api.py
@@ -11,11 +11,30 @@ from .types import StockPrice
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://stock.indianapi.in"
-POLL_INTERVAL = 15
-MAX_POLL_INTERVAL = 300
-POLL_JITTER = 5.0
-REQUEST_TIMEOUT = 10.0
-HISTORY_LIMIT = 200
+
+# --------------------------------------------------------------------------- #
+# Rate-limit and quota constants                                               #
+# --------------------------------------------------------------------------- #
+
+MONTHLY_QUOTA = 5000        # maximum API calls per calendar month
+QUOTA_SAFETY_FACTOR = 0.9   # use only 90 % of the quota to leave headroom
+MIN_CALL_INTERVAL = 1.0     # hard rate limit: at most 1 request per second
+
+SECONDS_PER_MONTH = 30 * 24 * 3600  # conservative 30-day month = 2,592,000 s
+
+# Minimum wait between consecutive API calls to stay within monthly quota.
+# Formula: total_seconds / (monthly_budget × safety_factor)
+# = 2,592,000 / (5,000 × 0.9) ≈ 576 s
+# The max() ensures we never violate the 1-req/sec hard rate limit either.
+QUOTA_CALL_INTERVAL: float = max(
+    MIN_CALL_INTERVAL,
+    SECONDS_PER_MONTH / (MONTHLY_QUOTA * QUOTA_SAFETY_FACTOR),
+)
+
+POLL_JITTER = 10.0          # random jitter added to each sleep (seconds)
+REQUEST_TIMEOUT = 10.0      # HTTP request timeout (seconds)
+MAX_BACKOFF_DELAY = 3600.0  # cap consecutive-failure backoff at 1 hour
+HISTORY_LIMIT = 200         # rolling price history buffer per ticker
 
 
 def _parse_response(ticker: str, data: dict, prev: StockPrice | None) -> StockPrice | None:
@@ -62,6 +81,10 @@ class IndianAPIProvider(MarketDataProvider):
         self._cache: dict[str, StockPrice] = {}
         self._history: dict[str, list[StockPrice]] = {}
         self._task: asyncio.Task | None = None
+        # Monthly quota tracking (resets automatically on calendar-month rollover)
+        now = datetime.now(timezone.utc)
+        self._quota_month: tuple[int, int] = (now.year, now.month)
+        self._calls_this_month: int = 0
 
     async def start(self) -> None:
         if self._task is not None and not self._task.done():
@@ -93,25 +116,128 @@ class IndianAPIProvider(MarketDataProvider):
             self._history.pop(ticker, None)
         self._tickers = list(tickers)
 
+    # ---------------------------------------------------------------------- #
+    # Quota helpers                                                           #
+    # ---------------------------------------------------------------------- #
+
+    def _maybe_reset_monthly_quota(self) -> None:
+        """Reset the monthly call counter when a new calendar month begins."""
+        now = datetime.now(timezone.utc)
+        current_month = (now.year, now.month)
+        if current_month != self._quota_month:
+            self._calls_this_month = 0
+            self._quota_month = current_month
+            logger.info(
+                "Monthly API quota reset for %04d-%02d",
+                current_month[0],
+                current_month[1],
+            )
+
+    def get_quota_status(self) -> dict:
+        """Return current monthly API usage statistics."""
+        self._maybe_reset_monthly_quota()
+        return {
+            "calls_this_month": self._calls_this_month,
+            "monthly_quota": MONTHLY_QUOTA,
+            "calls_remaining": max(0, MONTHLY_QUOTA - self._calls_this_month),
+            "quota_month": f"{self._quota_month[0]:04d}-{self._quota_month[1]:02d}",
+        }
+
+    # ---------------------------------------------------------------------- #
+    # Polling implementation                                                  #
+    # ---------------------------------------------------------------------- #
+
     async def _poll_loop(self) -> None:
+        """Round-robin over all tracked tickers, honouring rate and quota limits.
+
+        One API call is made per iteration (single ticker), then the loop sleeps
+        for QUOTA_CALL_INTERVAL seconds. This ensures:
+        - At most 1 request per QUOTA_CALL_INTERVAL seconds (≈576 s)
+        - Monthly usage stays within MONTHLY_QUOTA × QUOTA_SAFETY_FACTOR calls
+        - The 1-req/sec hard rate limit is never violated
+
+        With N tickers, each individual ticker is refreshed every
+        QUOTA_CALL_INTERVAL × N seconds (≈96 min for 10 tickers).
+        """
+        ticker_index = 0
         consecutive_failures = 0
+
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
             while True:
-                if self._tickers:
-                    successes = await self._poll_all(client)
-                    if successes == 0:
-                        consecutive_failures += 1
-                    else:
-                        consecutive_failures = 0
-                else:
+                tickers = self._tickers  # snapshot; list may change between iterations
+
+                if not tickers:
+                    await asyncio.sleep(QUOTA_CALL_INTERVAL)
                     consecutive_failures = 0
-                delay = min(POLL_INTERVAL * (2 ** consecutive_failures), MAX_POLL_INTERVAL)
+                    continue
+
+                # Enforce monthly quota before making a call
+                self._maybe_reset_monthly_quota()
+                if self._calls_this_month >= MONTHLY_QUOTA:
+                    logger.warning(
+                        "Monthly API quota of %d calls exhausted (%d used). "
+                        "Polling paused until next month.",
+                        MONTHLY_QUOTA,
+                        self._calls_this_month,
+                    )
+                    await asyncio.sleep(3600)  # re-check hourly
+                    continue
+
+                # Round-robin: advance index, wrapping if the ticker list changed
+                ticker_index = ticker_index % len(tickers)
+                ticker = tickers[ticker_index]
+                ticker_index += 1
+
+                success = await self._poll_one(client, ticker)
+                if success:
+                    consecutive_failures = 0
+                else:
+                    consecutive_failures += 1
+
+                # Exponential backoff on consecutive failures, capped at MAX_BACKOFF_DELAY
+                if consecutive_failures:
+                    delay = min(
+                        QUOTA_CALL_INTERVAL * (2**consecutive_failures),
+                        MAX_BACKOFF_DELAY,
+                    )
+                else:
+                    delay = QUOTA_CALL_INTERVAL
+
                 delay += random.uniform(0, POLL_JITTER)
                 await asyncio.sleep(delay)
+
+    async def _poll_one(self, client: httpx.AsyncClient, ticker: str) -> bool:
+        """Fetch and cache the latest price for a single ticker.
+
+        Increments the monthly call counter regardless of success or failure
+        (a network error still consumes quota on the provider side).
+        Returns True on success, False on any error.
+        """
+        self._calls_this_month += 1
+        try:
+            data = await _fetch_one(client, ticker, self._api_key)
+        except Exception as exc:
+            logger.warning("IndianAPI poll failed for %s: %s", ticker, exc)
+            return False
+
+        prev = self._cache.get(ticker)
+        sp = _parse_response(ticker, data, prev)
+        if sp is None:
+            logger.warning("IndianAPI: no valid price in response for %s", ticker)
+            return False
+
+        self._cache[ticker] = sp
+        buf = self._history.setdefault(ticker, [])
+        buf.append(sp)
+        if len(buf) > HISTORY_LIMIT:
+            self._history[ticker] = buf[-HISTORY_LIMIT:]
+        return True
 
     async def _poll_all(self, client: httpx.AsyncClient) -> int:
         """Fetch all tickers concurrently; log errors without interrupting the stream.
 
+        Retained for use in tests. In production the poll loop uses the
+        rate-limited round-robin _poll_one path instead.
         Returns the number of tickers successfully updated.
         """
         tasks = [_fetch_one(client, t, self._api_key) for t in self._tickers]

--- a/backend/tests/test_indian_api.py
+++ b/backend/tests/test_indian_api.py
@@ -6,6 +6,8 @@ import respx
 
 from market.indian_api import (
     BASE_URL,
+    MONTHLY_QUOTA,
+    QUOTA_CALL_INTERVAL,
     IndianAPIProvider,
     _fetch_one,
     _parse_response,
@@ -438,3 +440,143 @@ async def test_poll_all_returns_zero_on_all_failures():
         count = await provider._poll_all(client)
 
     assert count == 0
+
+
+# ── _poll_one ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_poll_one_success_returns_true():
+    respx.get(f"{BASE_URL}/stock").mock(
+        return_value=httpx.Response(200, json=SAMPLE_RESPONSE)
+    )
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE"])
+    async with httpx.AsyncClient() as client:
+        result = await provider._poll_one(client, "RELIANCE")
+    assert result is True
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_poll_one_failure_returns_false():
+    respx.get(f"{BASE_URL}/stock").mock(return_value=httpx.Response(500))
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE"])
+    async with httpx.AsyncClient() as client:
+        result = await provider._poll_one(client, "RELIANCE")
+    assert result is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_poll_one_populates_cache():
+    respx.get(f"{BASE_URL}/stock").mock(
+        return_value=httpx.Response(200, json=SAMPLE_RESPONSE)
+    )
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE"])
+    async with httpx.AsyncClient() as client:
+        await provider._poll_one(client, "RELIANCE")
+    sp = provider.get_price("RELIANCE")
+    assert sp is not None
+    assert sp.price == 2195.75
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_poll_one_increments_quota_counter_on_success():
+    respx.get(f"{BASE_URL}/stock").mock(
+        return_value=httpx.Response(200, json=SAMPLE_RESPONSE)
+    )
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE"])
+    assert provider._calls_this_month == 0
+    async with httpx.AsyncClient() as client:
+        await provider._poll_one(client, "RELIANCE")
+    assert provider._calls_this_month == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_poll_one_increments_quota_counter_on_failure():
+    # Counter increments even when the request fails (still costs quota)
+    respx.get(f"{BASE_URL}/stock").mock(return_value=httpx.Response(429))
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE"])
+    async with httpx.AsyncClient() as client:
+        await provider._poll_one(client, "RELIANCE")
+    assert provider._calls_this_month == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_poll_one_accumulates_history():
+    respx.get(f"{BASE_URL}/stock").mock(
+        return_value=httpx.Response(200, json=SAMPLE_RESPONSE)
+    )
+    provider = IndianAPIProvider("test-key")
+    provider.set_tickers(["RELIANCE"])
+    async with httpx.AsyncClient() as client:
+        await provider._poll_one(client, "RELIANCE")
+        await provider._poll_one(client, "RELIANCE")
+    assert len(provider.get_history("RELIANCE")) == 2
+
+
+# ── Quota tracking ───────────────────────────────────────────────────────────
+
+
+def test_get_quota_status_initial():
+    provider = IndianAPIProvider("test-key")
+    status = provider.get_quota_status()
+    assert status["calls_this_month"] == 0
+    assert status["monthly_quota"] == MONTHLY_QUOTA
+    assert status["calls_remaining"] == MONTHLY_QUOTA
+
+
+def test_get_quota_status_decrements_remaining():
+    provider = IndianAPIProvider("test-key")
+    provider._calls_this_month = 100
+    status = provider.get_quota_status()
+    assert status["calls_remaining"] == MONTHLY_QUOTA - 100
+
+
+def test_get_quota_status_remaining_floor_at_zero():
+    provider = IndianAPIProvider("test-key")
+    provider._calls_this_month = MONTHLY_QUOTA + 50
+    status = provider.get_quota_status()
+    assert status["calls_remaining"] == 0
+
+
+def test_quota_resets_on_new_month():
+    provider = IndianAPIProvider("test-key")
+    # Simulate being in a previous month
+    provider._calls_this_month = 3000
+    provider._quota_month = (2020, 1)
+    # Calling _maybe_reset_monthly_quota should detect the month change and reset
+    provider._maybe_reset_monthly_quota()
+    assert provider._calls_this_month == 0
+
+
+def test_quota_does_not_reset_same_month():
+    provider = IndianAPIProvider("test-key")
+    provider._calls_this_month = 3000
+    # Keep the same month as now
+    now = datetime.now(timezone.utc)
+    provider._quota_month = (now.year, now.month)
+    provider._maybe_reset_monthly_quota()
+    assert provider._calls_this_month == 3000
+
+
+def test_quota_call_interval_respects_rate_limit():
+    # QUOTA_CALL_INTERVAL must always be >= MIN_CALL_INTERVAL (1 req/sec)
+    assert QUOTA_CALL_INTERVAL >= 1.0
+
+
+def test_quota_call_interval_within_monthly_budget():
+    # At QUOTA_CALL_INTERVAL seconds per call, monthly calls must stay under MONTHLY_QUOTA
+    from market.indian_api import SECONDS_PER_MONTH
+
+    calls_per_month = SECONDS_PER_MONTH / QUOTA_CALL_INTERVAL
+    assert calls_per_month <= MONTHLY_QUOTA


### PR DESCRIPTION
Fixes #10

Switches from concurrent batch polling (all tickers every 15s) to a rate-limited round-robin that polls one ticker per ~576 seconds, keeping monthly usage within the 5,000 call quota with a 10% safety buffer.

Generated with [Claude Code](https://claude.ai/code)